### PR TITLE
Fix index key visibility

### DIFF
--- a/struct_db_macro/src/struct_db.rs
+++ b/struct_db_macro/src/struct_db.rs
@@ -121,7 +121,8 @@ pub fn struct_db(args: TokenStream, input: TokenStream) -> TokenStream {
             }
         }
 
-        enum #keys_enum_name_token {
+        /// Index selection Enum for [#struct_name]
+        pub(crate) enum #keys_enum_name_token {
             #(#keys_enum_tokens),*
         }
 


### PR DESCRIPTION
Change the visibility of the key enum to
pub(crate) so the database can be used in the crate.

The enum can then be exported if required in another module.